### PR TITLE
Use new pyhsm_msgs names and rename topics

### DIFF
--- a/src/hsm/introspection.py
+++ b/src/hsm/introspection.py
@@ -14,11 +14,11 @@ from hsm import msg_builder
 __all__ = ['IntrospectionClient', 'IntrospectionServer']
 
 # Topic names
-STATUS_TOPIC = '/smach/container_status'
+STATUS_TOPIC = '/current_state'
 INIT_TOPIC = '/smach/container_init'
-STRUCTURE_TOPIC = '/smach/container_structure'
-TRANSITION_TOPIC = '/smach/transition'
-EVENT_TOPIC = '/smach/event'
+STRUCTURE_TOPIC = '/structure'
+TRANSITION_TOPIC = '/transition'
+EVENT_TOPIC = '/event'
 
 
 class IntrospectionClient():

--- a/src/hsm/msg_builder.py
+++ b/src/hsm/msg_builder.py
@@ -12,15 +12,15 @@ from hsm.core import _History
 HISTORY_TRANSITION_MAGIC_WORD = '__HISTORY'
 
 # Types for the public API
-STATUS_MSG = msgs.HsmStatus
+STATUS_MSG = msgs.HsmCurrentState
 STRUCTURE_MSG = msgs.HsmStructure
 
 # What type to filter ROS topics by to get these messages
-STATUS_MSG_TOPIC_TYPE = 'pyhsm_msgs/HsmStatus'
+STATUS_MSG_TOPIC_TYPE = 'pyhsm_msgs/HsmCurrentState'
 
 
 def build_status_msg(path):
-    return msgs.HsmStatus(path)
+    return msgs.HsmCurrentState(path)
 
 
 def build_structure_msg(prefix, machine):

--- a/src/viewer.py
+++ b/src/viewer.py
@@ -47,9 +47,6 @@ import wx
 import wx.richtext
 import textwrap
 
-TRANSITION_TOPIC = '/smach/transition'
-EVENT_TOPIC = '/smach/event'
-
 ## this import system (or ros-released) xdot
 # import xdot
 ## need to import currnt package, but not to load this file
@@ -661,8 +658,8 @@ class SmachViewerFrame(wx.Frame):
         parent_path = get_parent_path(state_path)
 
         server_name = self._containers[parent_path]._server_name
-        transition_pub = rospy.Publisher(server_name + TRANSITION_TOPIC,
-                                   String, queue_size=1)
+        transition_pub = rospy.Publisher(server_name + hsm.introspection.TRANSITION_TOPIC,
+                                         String, queue_size=1)
         transition_msg = String()
         transition_msg.data = state_path
         transition_pub.publish(transition_msg)
@@ -670,8 +667,8 @@ class SmachViewerFrame(wx.Frame):
     def on_trigger_event(self, event):
         """Event: Dispatch an event in the hsm."""
         server_name = self._containers[self._path]._server_name
-        event_pub = rospy.Publisher(server_name + EVENT_TOPIC,
-                                   String, queue_size=1)
+        event_pub = rospy.Publisher(server_name + hsm.introspection.EVENT_TOPIC,
+                                    String, queue_size=1)
         event_msg = String(self.event_combo.GetValue())
         event_pub.publish(event_msg)
 


### PR DESCRIPTION
Ref https://github.com/ubi-agni/pyhsm_msgs/pull/2.
Accordingly, (used) topics have been given more sensible names.