### PR TITLE
Use a latched publisher for status messages

### DIFF
--- a/src/hsm/introspection.py
+++ b/src/hsm/introspection.py
@@ -244,8 +244,8 @@ class IntrospectionServer():
         # TODO after rework, uncomment and
         #      maybe remove `_publish_structure` line
         # self._structure_pub_thread.start()
-        self._publish_structure('INITIAL')
-        self._publish_status('INITIAL_STATE')
+        self._publish_structure()
+        self._publish_status()
 
         self._transition_cmd = rospy.Subscriber(
             self._server_name + TRANSITION_TOPIC,
@@ -296,7 +296,7 @@ class IntrospectionServer():
 
     def _transition_cb(self, from_state, to_state):
         self._active_path = self._get_full_path(to_state)
-        self._publish_status('TRANSITION')
+        self._publish_status()
 
     @staticmethod
     def _get_full_path(state):
@@ -339,7 +339,7 @@ class IntrospectionServer():
             except:
                 pass
 
-    def _publish_structure(self, info_str=''):
+    def _publish_structure(self):
         path = self._path
 
         structure_msg = msg_builder.build_structure_msg(path, self._machine)
@@ -350,7 +350,7 @@ class IntrospectionServer():
                 rospy.logerr(
                     "Publishing SMACH introspection structure message failed.")
 
-    def _publish_status(self, info_str=''):
+    def _publish_status(self):
         """Publish current state of this container."""
         # Construct messages
         with self._status_pub_lock:

--- a/src/hsm/introspection.py
+++ b/src/hsm/introspection.py
@@ -223,17 +223,13 @@ class IntrospectionServer():
         self._status_pub = rospy.Publisher(
             name=server_name + STATUS_TOPIC,
             data_class=msg_builder.STATUS_MSG,
-            queue_size=1)
+            queue_size=1,
+            latch=True)
 
         # TODO While the function is not reworked, we can comment this out.
         # self._structure_pub_thread = threading.Thread(
         #     name=server_name + ':structure_publisher',
         #     target=self._structure_pub_loop)
-
-        # Create thread to constantly publish
-        self._status_pub_thread = threading.Thread(
-            name=server_name + ':status_publisher',
-            target=self._status_pub_loop)
 
         self._keep_running = False
 
@@ -249,7 +245,7 @@ class IntrospectionServer():
         #      maybe remove `_publish_structure` line
         # self._structure_pub_thread.start()
         self._publish_structure('INITIAL')
-        self._status_pub_thread.start()
+        self._publish_status('INITIAL_STATE')
 
         self._transition_cmd = rospy.Subscriber(
             self._server_name + TRANSITION_TOPIC,
@@ -353,18 +349,6 @@ class IntrospectionServer():
             if not rospy.is_shutdown():
                 rospy.logerr(
                     "Publishing SMACH introspection structure message failed.")
-
-    def _status_pub_loop(self):
-        """Loop to publish the status heartbeat."""
-        while not rospy.is_shutdown() and self._keep_running:
-            # TODO
-            self._publish_status('HEARTBEAT')
-            try:
-                end_time = rospy.Time.now() + self._update_rate
-                while not rospy.is_shutdown() and rospy.Time.now() < end_time:
-                    rospy.sleep(0.1)
-            except:
-                pass
 
     def _publish_status(self, info_str=''):
         """Publish current state of this container."""

--- a/src/viewer.py
+++ b/src/viewer.py
@@ -426,6 +426,16 @@ class SmachViewerFrame(wx.Frame):
     """
     This class provides a GUI application for viewing SMACH plans.
     """
+
+    STATUS_MSG_TIMEOUT = 2
+    """Seconds we wait for a container referenced in a status message to appear.
+    After that, we assume something went wrong and ignore the message.
+    """
+    STATUS_MSG_SLEEP_DURATION = 0.1
+    """Period in seconds that we sleep while waiting for a container referenced
+    in a status message to appear.
+    """
+
     def __init__(self):
         wx.Frame.__init__(self, None, -1, "Smach Viewer", size=(720,480))
 
@@ -922,6 +932,12 @@ class SmachViewerFrame(wx.Frame):
         # Get the path to the updating conainer
         path = msg.path
         rospy.logdebug("STATUS MSG: "+path)
+
+        # Avoid the race condition of obtaining the status of a new tree before its structure
+        sleep_stopwatch = 0
+        while path not in self._containers and sleep_stopwatch < self.STATUS_MSG_TIMEOUT:
+            rospy.sleep(self.STATUS_MSG_SLEEP_DURATION)
+            sleep_stopwatch += self.STATUS_MSG_SLEEP_DURATION
 
         # Check if this is a known container
         needs_update = False


### PR DESCRIPTION
Avoids looping to send 'heartbeat' messages with the current status. Due to this change, an old race condition had to be fixed as well.