### PR TITLE
Small patches and fixes

### DIFF
--- a/src/viewer.py
+++ b/src/viewer.py
@@ -763,6 +763,8 @@ class HsmViewerFrame(wx.Frame):
             # Update the graph
             self._structure_changed = True
             self._needs_zoom = True  # TODO: Make it so you can disable this
+            self._needs_graph_update = True
+            self._needs_tree_update = True
             self._update_cond.notify_all()
 
         # After first structure message, when structure tree was built, create status subscriber
@@ -907,6 +909,8 @@ class HsmViewerFrame(wx.Frame):
                 rospy.logwarn("unknown state: " + path)
 
             if needs_update:
+                self._needs_graph_update = True
+                self._needs_tree_update = True
                 self._update_cond.notify_all()
 
     def _update_parents(self, path, set_active):

--- a/src/viewer.py
+++ b/src/viewer.py
@@ -637,7 +637,7 @@ class HsmViewerFrame(wx.Frame):
 
     def set_path(self, event):
         """Event: Change the viewable path and update the graph."""
-        self._path = self.path_filter_combo.GetValue()
+        self._path = self.path_filter_combo.GetValue() or '/'
         self._needs_zoom = True
         self.update_graph()
 


### PR DESCRIPTION
1. Rename path combo boxes to sensible names.
2. Accept empty path in path filter.
3. Fix missing graph/tree update conditions.

Can split up into multiple PRs if desired.